### PR TITLE
feat(icon): Suggest using 'circle-stop' icon instead of 'Square' for stop action

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     network_mode: host
 
   app:
-    image: ghcr.io/plutack/pad.ws:feat-improve-stop-icon
+    image: ghcr.io/pad-ws/pad.ws:main
     container_name: pad
     environment:
       - STATIC_DIR=/app/frontend/dist

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     network_mode: host
 
   app:
-    image: ghcr.io/pad-ws/pad.ws:main
+    image: ghcr.io/plutack/pad.ws:feat-improve-stop-icon
     container_name: pad
     environment:
       - STATIC_DIR=/app/frontend/dist

--- a/src/frontend/src/pad/controls/ControlButton.tsx
+++ b/src/frontend/src/pad/controls/ControlButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useWorkspaceState, useStartWorkspace, useStopWorkspace } from '../../api/hooks';
 import '../styles/index.scss';
-import { Play, CircleX, LoaderCircle } from 'lucide-react';
+import { Play, CircleStop, LoaderCircle } from 'lucide-react';
 
 export const ControlButton: React.FC = () => {
   const { data: workspaceState } = useWorkspaceState({
@@ -41,7 +41,7 @@ export const ControlButton: React.FC = () => {
         className="control-button"
         aria-label="Stop VM"
       >
-        <CircleX className="control-icon" color="black" />
+        <CircleStop className="control-icon" color="#c72b2b" />
       </button>
     );
   } else {

--- a/src/frontend/src/pad/controls/ControlButton.tsx
+++ b/src/frontend/src/pad/controls/ControlButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useWorkspaceState, useStartWorkspace, useStopWorkspace } from '../../api/hooks';
 import '../styles/index.scss';
-import { Play, Square, LoaderCircle } from 'lucide-react';
+import { Play, CircleX, LoaderCircle } from 'lucide-react';
 
 export const ControlButton: React.FC = () => {
   const { data: workspaceState } = useWorkspaceState({
@@ -41,7 +41,7 @@ export const ControlButton: React.FC = () => {
         className="control-button"
         aria-label="Stop VM"
       >
-        <Square className="control-icon" color="black" />
+        <CircleX className="control-icon" color="black" />
       </button>
     );
   } else {


### PR DESCRIPTION
# Description

This is an opinionated PR to change the square ocon to terminate the workspace to another icon

## Motivation
While, I tried tesing locally, For a few seconds, I thought the squre button meant for terminating was actually a checkbox. 
