### PR TITLE
feat: hide embeddable hyperlinks for custom pad elements

### DIFF
--- a/src/frontend/src/lib/ExcalidrawElementFactory.ts
+++ b/src/frontend/src/lib/ExcalidrawElementFactory.ts
@@ -119,7 +119,10 @@ export class ExcalidrawElementFactory {
     return {
       ...element,
       type: "embeddable",
-      link: options.link
+      link: options.link,
+      customData: {
+        showHyperlinkIcon: false
+      }
     };
   }
 


### PR DESCRIPTION
Using a [feature from our custom Excalidraw fork](https://github.com/atyrode/excalidraw/commit/d1cfd7db1efb53b69beae5170332e73ad7149581), we can now hide the "hyperlinks" from our elements:

<img width="710" alt="Screenshot 2025-04-23 at 23 06 46" src="https://github.com/user-attachments/assets/238445eb-deef-497d-8ebb-f67b58ccaf9d" />

This is done using the `customData` field on the elements, and setting `showHyperlinkIcon` to false, such as the following example:

```json
{
    "type": "excalidraw/clipboard",
    "elements": [
        {
            ...
            "customData": {
                "showHyperlinkIcon": false
            },
            ...
           }
     ]
}
```

Resulting in a much nicer experience:

<img width="445" alt="Screenshot 2025-04-23 at 23 12 22" src="https://github.com/user-attachments/assets/ee70b612-261d-4a80-8e37-e45e0a090cc4" />