### PR TITLE
chore: add support for multi-platform builds in Docker workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,6 +51,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          builder: ${{ steps.buildx.outputs.name }} 
+          builder: ${{ steps.buildx.outputs.name }}


### PR DESCRIPTION
This adds `platforms: linux/amd64,linux/arm64`to the `docker-build.yml` GitHub action of the repository to cover more architectures.
