### PR TITLE
fix: unified grid settings

### DIFF
--- a/src/frontend/src/ExcalidrawWrapper.tsx
+++ b/src/frontend/src/ExcalidrawWrapper.tsx
@@ -11,7 +11,7 @@ const defaultInitialData = {
   elements: [],
   appState: {
     gridModeEnabled: true,
-    gridSize: 40,
+    gridSize: 20,
     gridStep: 5,
   },
   files: {},


### PR DESCRIPTION
The grid settings were different in the initial data passed to Excalidraw meaning you could load the website and see a different grid behind the modal, than once you sign in.