### PR TITLE
fix: update CI workflow for consistency, change manifest/digest logic

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,7 +12,6 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  # Job for AMD64 architecture
   build-amd64:
     runs-on: ubuntu-latest
     permissions:
@@ -74,7 +73,6 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # Job for ARM64 architecture - runs on all events
   build-arm64:
     runs-on: ubuntu-latest
     permissions:
@@ -119,8 +117,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           builder: ${{ steps.buildx.outputs.name }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Export ARM64 digest
         run: |
           mkdir -p /tmp/digests

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,14 +12,20 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-amd64:
+  build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [linux/amd64, linux/arm64]
     permissions:
       contents: read
       packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -31,6 +37,13 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract platform short name
+        id: platform
+        run: |
+          # Extract the architecture from the platform (e.g., amd64 from linux/amd64)
+          ARCH=$(echo "${{ matrix.platform }}" | cut -d/ -f2)
+          echo "arch=${ARCH}" >> $GITHUB_OUTPUT
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -44,114 +57,24 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha,format=long
 
-      - name: Build and push AMD64 Docker image
-        id: build
+      - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}-amd64
+          platforms: ${{ matrix.platform }}
+          tags: ${{ steps.meta.outputs.tags }}-${{ steps.platform.outputs.arch }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          builder: ${{ steps.buildx.outputs.name }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      - name: Export AMD64 digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-          echo "AMD64_DIGEST=${digest}" >> $GITHUB_ENV
 
-      - name: Upload AMD64 digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: amd64-digest
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  build-arm64:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        id: buildx
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,format=long
-
-      - name: Build and push ARM64 Docker image
-        id: build
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}-arm64
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          builder: ${{ steps.buildx.outputs.name }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      - name: Export ARM64 digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-          echo "ARM64_DIGEST=${digest}" >> $GITHUB_ENV
-
-      - name: Upload ARM64 digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: arm64-digest
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  # Job to create multi-architecture manifest
   create-manifest:
     runs-on: ubuntu-latest
-    needs: [build-amd64, build-arm64]
+    needs: build
     permissions:
       contents: read
       packages: write
     steps:
-      - name: Download AMD64 digest
-        uses: actions/download-artifact@v4
-        with:
-          name: amd64-digest
-          path: /tmp/digests/amd64
-
-      - name: Download ARM64 digest
-        uses: actions/download-artifact@v4
-        with:
-          name: arm64-digest
-          path: /tmp/digests/arm64
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -176,17 +99,16 @@ jobs:
 
       - name: Create manifest list and push
         run: |
-          # Get the first tag from meta outputs
-          FIRST_TAG=$(echo "${{ steps.meta.outputs.tags }}" | cut -d, -f1)
+          # Get the first tag from meta outputs (without newlines)
+          FIRST_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n 1)
           
-          # Use both digests
-          AMD64_DIGEST=$(cat /tmp/digests/amd64/*)
-          ARM64_DIGEST=$(cat /tmp/digests/arm64/*)
+          # Create manifest with both architecture images
           docker buildx imagetools create \
             --tag ${FIRST_TAG} \
-            ${AMD64_DIGEST} ${ARM64_DIGEST}
+            ${FIRST_TAG}-amd64 \
+            ${FIRST_TAG}-arm64
 
       - name: Inspect image
         run: |
-          FIRST_TAG=$(echo "${{ steps.meta.outputs.tags }}" | cut -d, -f1)
+          FIRST_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n 1)
           docker buildx imagetools inspect ${FIRST_TAG}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -56,8 +56,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           builder: ${{ steps.buildx.outputs.name }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Export AMD64 digest
         run: |
           mkdir -p /tmp/digests

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,7 +12,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  # Job for AMD64 architecture - runs on all events
+  # Job for AMD64 architecture
   build-amd64:
     runs-on: ubuntu-latest
     permissions:
@@ -27,7 +27,6 @@ jobs:
         id: buildx
 
       - name: Log in to the Container registry
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -51,17 +50,16 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}-amd64
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
           builder: ${{ steps.buildx.outputs.name }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export AMD64 digest
-        if: github.event_name != 'pull_request'
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
@@ -69,7 +67,6 @@ jobs:
           echo "AMD64_DIGEST=${digest}" >> $GITHUB_ENV
 
       - name: Upload AMD64 digest
-        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: amd64-digest
@@ -77,14 +74,12 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # Job for ARM64 architecture - only runs on main branch
+  # Job for ARM64 architecture - runs on all events
   build-arm64:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-    # Only run this job for pushes to main, not for PRs
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -107,6 +102,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
+            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,format=long
@@ -144,9 +140,6 @@ jobs:
   create-manifest:
     runs-on: ubuntu-latest
     needs: [build-amd64, build-arm64]
-    # This job only runs if at least build-amd64 completed successfully
-    # build-arm64 might be skipped for PRs, so we don't require it
-    if: github.event_name != 'pull_request' && always() && needs.build-amd64.result == 'success'
     permissions:
       contents: read
       packages: write
@@ -158,8 +151,6 @@ jobs:
           path: /tmp/digests/amd64
 
       - name: Download ARM64 digest
-        # Only try to download ARM64 digest if the job ran
-        if: needs.build-arm64.result == 'success'
         uses: actions/download-artifact@v4
         with:
           name: arm64-digest
@@ -182,6 +173,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
+            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,format=long
@@ -191,20 +183,12 @@ jobs:
           # Get the first tag from meta outputs
           FIRST_TAG=$(echo "${{ steps.meta.outputs.tags }}" | cut -d, -f1)
           
-          # If ARM64 build was skipped, only use AMD64 digest
-          if [ "${{ needs.build-arm64.result }}" != "success" ]; then
-            AMD64_DIGEST=$(cat /tmp/digests/amd64/*)
-            docker buildx imagetools create \
-              --tag ${FIRST_TAG} \
-              ${AMD64_DIGEST}
-          else
-            # Otherwise use both digests
-            AMD64_DIGEST=$(cat /tmp/digests/amd64/*)
-            ARM64_DIGEST=$(cat /tmp/digests/arm64/*)
-            docker buildx imagetools create \
-              --tag ${FIRST_TAG} \
-              ${AMD64_DIGEST} ${ARM64_DIGEST}
-          fi
+          # Use both digests
+          AMD64_DIGEST=$(cat /tmp/digests/amd64/*)
+          ARM64_DIGEST=$(cat /tmp/digests/arm64/*)
+          docker buildx imagetools create \
+            --tag ${FIRST_TAG} \
+            ${AMD64_DIGEST} ${ARM64_DIGEST}
 
       - name: Inspect image
         run: |

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -32,6 +32,8 @@ jobs:
         id: buildx
 
       - name: Log in to the Container registry
+        # Only login if we're pushing (not a PR)
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -61,7 +63,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
+          # Only push if not a PR
+          push: ${{ github.event_name != 'pull_request' }}
           platforms: ${{ matrix.platform }}
           tags: ${{ steps.meta.outputs.tags }}-${{ steps.platform.outputs.arch }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -69,6 +72,8 @@ jobs:
           cache-to: type=gha,mode=max
 
   create-manifest:
+    # Skip this job for pull requests
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: build
     permissions:
@@ -97,18 +102,24 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha,format=long
 
-      - name: Create manifest list and push
+      - name: Create manifest lists and push
         run: |
-          # Get the first tag from meta outputs (without newlines)
-          FIRST_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n 1)
-          
-          # Create manifest with both architecture images
-          docker buildx imagetools create \
-            --tag ${FIRST_TAG} \
-            ${FIRST_TAG}-amd64 \
-            ${FIRST_TAG}-arm64
+          # Process each tag and create a manifest for it
+          echo "${{ steps.meta.outputs.tags }}" | while read -r TAG; do
+            if [ -n "$TAG" ]; then
+              echo "Creating manifest for $TAG"
+              docker buildx imagetools create \
+                --tag $TAG \
+                $TAG-amd64 \
+                $TAG-arm64
+            fi
+          done
 
-      - name: Inspect image
+      - name: Inspect images
         run: |
-          FIRST_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n 1)
-          docker buildx imagetools inspect ${FIRST_TAG}
+          echo "${{ steps.meta.outputs.tags }}" | while read -r TAG; do
+            if [ -n "$TAG" ]; then
+              echo "Inspecting manifest for $TAG"
+              docker buildx imagetools inspect $TAG
+            fi
+          done

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Frontend build stage
-FROM node:20-slim as frontend-builder
+FROM node:20-slim AS frontend-builder
 WORKDIR /app/frontend
 
 # Copy package files first to leverage layer caching


### PR DESCRIPTION
The PR #23 complicated the CI/CD workflow too much and this reverts part of its logic to simplify the building flow.