### PR TITLE
refactor: simplify Docker build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,11 +12,8 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  build-and-push:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform: [linux/amd64, linux/arm64]
     permissions:
       contents: read
       packages: write
@@ -32,20 +29,12 @@ jobs:
         id: buildx
 
       - name: Log in to the Container registry
-        # Only login if we're pushing (not a PR)
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract platform short name
-        id: platform
-        run: |
-          # Extract the architecture from the platform (e.g., amd64 from linux/amd64)
-          ARCH=$(echo "${{ matrix.platform }}" | cut -d/ -f2)
-          echo "arch=${ARCH}" >> $GITHUB_OUTPUT
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -63,63 +52,9 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          # Only push if not a PR
           push: ${{ github.event_name != 'pull_request' }}
-          platforms: ${{ matrix.platform }}
-          tags: ${{ steps.meta.outputs.tags }}-${{ steps.platform.outputs.arch }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  create-manifest:
-    # Skip this job for pull requests
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,format=long
-
-      - name: Create manifest lists and push
-        run: |
-          # Process each tag and create a manifest for it
-          echo "${{ steps.meta.outputs.tags }}" | while read -r TAG; do
-            if [ -n "$TAG" ]; then
-              echo "Creating manifest for $TAG"
-              docker buildx imagetools create \
-                --tag $TAG \
-                $TAG-amd64 \
-                $TAG-arm64
-            fi
-          done
-
-      - name: Inspect images
-        run: |
-          echo "${{ steps.meta.outputs.tags }}" | while read -r TAG; do
-            if [ -n "$TAG" ]; then
-              echo "Inspecting manifest for $TAG"
-              docker buildx imagetools inspect $TAG
-            fi
-          done


### PR DESCRIPTION
Seems like I wasn't done with trouble in #23 and #24. I tried to implement a better but more complex approach at multi-job multi-platform build but was not succesful and therefore will revert to a single-job, multi-platform build for the pad.ws packages.