### PR TITLE
feat: add settings menu

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@atyrode/excalidraw": "^0.18.0-3",
+    "@atyrode/excalidraw": "^0.18.0-4",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.74.3",
     "@tanstack/react-query-devtools": "^5.74.3",

--- a/src/frontend/src/ExcalidrawWrapper.tsx
+++ b/src/frontend/src/ExcalidrawWrapper.tsx
@@ -59,6 +59,7 @@ export const ExcalidrawWrapper: React.FC<ExcalidrawWrapperProps> = ({
     }
   }, [isAuthenticated]);
   
+  
   // Handlers for closing modals
   const handleCloseBackupsModal = () => {
     setShowBackupsModal(false);
@@ -122,6 +123,7 @@ export const ExcalidrawWrapper: React.FC<ExcalidrawWrapperProps> = ({
         
         {showSettingsModal && (
           <SettingsDialog
+            excalidrawAPI={excalidrawAPI}
             onClose={handleCloseSettingsModal}
           />
         )}

--- a/src/frontend/src/ExcalidrawWrapper.tsx
+++ b/src/frontend/src/ExcalidrawWrapper.tsx
@@ -8,6 +8,7 @@ import { MainMenuConfig } from './ui/MainMenu';
 import { lockEmbeddables, renderCustomEmbeddable } from './CustomEmbeddableRenderer';
 import AuthDialog from './ui/AuthDialog';
 import BackupsModal from './ui/BackupsDialog';
+import SettingsDialog from './ui/SettingsDialog';
 
 const defaultInitialData = {
   elements: [],
@@ -47,8 +48,9 @@ export const ExcalidrawWrapper: React.FC<ExcalidrawWrapperProps> = ({
   // Add state for modal animation
   const [isExiting, setIsExiting] = useState(false);
   
-  // State for BackupsModal
+  // State for modals
   const [showBackupsModal, setShowBackupsModal] = useState(false);
+  const [showSettingsModal, setShowSettingsModal] = useState(false);
   
   // Handle auth state changes
   useEffect(() => {
@@ -57,9 +59,13 @@ export const ExcalidrawWrapper: React.FC<ExcalidrawWrapperProps> = ({
     }
   }, [isAuthenticated]);
   
-  // Handler for closing the backups modal
+  // Handlers for closing modals
   const handleCloseBackupsModal = () => {
     setShowBackupsModal(false);
+  };
+  
+  const handleCloseSettingsModal = () => {
+    setShowSettingsModal(false);
   };
   
   const renderExcalidraw = (children: React.ReactNode) => {
@@ -98,6 +104,8 @@ export const ExcalidrawWrapper: React.FC<ExcalidrawWrapperProps> = ({
           excalidrawAPI={excalidrawAPI} 
           showBackupsModal={showBackupsModal}
           setShowBackupsModal={setShowBackupsModal}
+          showSettingsModal={showSettingsModal}
+          setShowSettingsModal={setShowSettingsModal}
         />
         {!isAuthLoading && isAuthenticated === false && (
           <AuthDialog 
@@ -109,6 +117,12 @@ export const ExcalidrawWrapper: React.FC<ExcalidrawWrapperProps> = ({
           <BackupsModal
             excalidrawAPI={excalidrawAPI}
             onClose={handleCloseBackupsModal}
+          />
+        )}
+        
+        {showSettingsModal && (
+          <SettingsDialog
+            onClose={handleCloseSettingsModal}
           />
         )}
       </>

--- a/src/frontend/src/ExcalidrawWrapper.tsx
+++ b/src/frontend/src/ExcalidrawWrapper.tsx
@@ -89,7 +89,10 @@ export const ExcalidrawWrapper: React.FC<ExcalidrawWrapperProps> = ({
         initialData: initialData ?? defaultInitialData,
         onChange: onChange,
         name: "Pad.ws",
-        onScrollChange: lockEmbeddables,
+        onScrollChange: (scrollX, scrollY) => {
+          lockEmbeddables(excalidrawAPI?.getAppState());
+          if (onScrollChange) onScrollChange(scrollX, scrollY);
+        },
         validateEmbeddable: true,
         renderEmbeddable: (element, appState) => renderCustomEmbeddable(element, appState, excalidrawAPI),
         renderTopRightUI: renderTopRightUI ?? (() => (

--- a/src/frontend/src/types/settings.ts
+++ b/src/frontend/src/types/settings.ts
@@ -1,0 +1,16 @@
+/**
+ * Types for user settings
+ */
+
+export interface UserSettings {
+  /**
+   * The debounce time in milliseconds for the embed lock
+   * Range: 150ms to 5000ms (5 seconds)
+   * Default: 350ms
+   */
+  embedLockDebounceTime?: number;
+}
+
+export const DEFAULT_SETTINGS: UserSettings = {
+  embedLockDebounceTime: 350, // Default value from CustomEmbeddableRenderer.tsx
+};

--- a/src/frontend/src/ui/MainMenu.tsx
+++ b/src/frontend/src/ui/MainMenu.tsx
@@ -3,17 +3,20 @@ import React, { useState } from 'react';
 import type { ExcalidrawImperativeAPI } from '@atyrode/excalidraw/types';
 import type { MainMenu as MainMenuType } from '@atyrode/excalidraw';
 
-import { LogOut, SquarePlus, LayoutDashboard, SquareCode, Eye, Coffee, Grid2x2, User, Text, ArchiveRestore } from 'lucide-react';
+import { LogOut, SquarePlus, LayoutDashboard, SquareCode, Eye, Coffee, Grid2x2, User, Text, ArchiveRestore, Settings } from 'lucide-react';
 import { capture } from '../utils/posthog';
 import { ExcalidrawElementFactory, PlacementMode } from '../lib/ExcalidrawElementFactory';
 import { useUserProfile } from "../api/hooks";
 import { queryClient } from "../api/queryClient";
+import SettingsDialog from "./SettingsDialog";
 import "./MainMenu.scss";
 interface MainMenuConfigProps {
   MainMenu: typeof MainMenuType;
   excalidrawAPI: ExcalidrawImperativeAPI | null;
   showBackupsModal: boolean;
   setShowBackupsModal: (show: boolean) => void;
+  showSettingsModal?: boolean;
+  setShowSettingsModal?: (show: boolean) => void;
 }
 
 export const MainMenuConfig: React.FC<MainMenuConfigProps> = ({
@@ -21,6 +24,8 @@ export const MainMenuConfig: React.FC<MainMenuConfigProps> = ({
   excalidrawAPI,
   showBackupsModal,
   setShowBackupsModal,
+  showSettingsModal = false,
+  setShowSettingsModal = (show: boolean) => {},
 }) => {
   const { data, isLoading, isError } = useUserProfile();
 
@@ -98,6 +103,10 @@ export const MainMenuConfig: React.FC<MainMenuConfigProps> = ({
 
   const handleCanvasBackupsClick = () => {
     setShowBackupsModal(true);
+  };
+
+  const handleSettingsClick = () => {
+    setShowSettingsModal(true);
   };
 
   const handleGridToggle = () => {
@@ -206,6 +215,13 @@ export const MainMenuConfig: React.FC<MainMenuConfigProps> = ({
       </MainMenu.Group>
       
       <MainMenu.Separator />
+      
+      <MainMenu.Item
+          icon={<Settings />}
+          onClick={handleSettingsClick}
+        >
+          Settings
+        </MainMenu.Item>
       
       <MainMenu.Item
           icon={<LogOut />}

--- a/src/frontend/src/ui/Range.scss
+++ b/src/frontend/src/ui/Range.scss
@@ -1,0 +1,71 @@
+:root {
+  --slider-thumb-size: 16px;
+}
+
+.control-label {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  font-size: 0.9rem;
+  color: var(--text-primary-color);
+}
+
+.range-wrapper {
+  position: relative;
+  padding-top: 10px;
+  padding-bottom: 25px;
+  width: 100%;
+}
+
+.range-input {
+  width: 100%;
+  height: 4px;
+  -webkit-appearance: none;
+  background: var(--color-slider-track);
+  border-radius: 2px;
+  outline: none;
+}
+
+.range-input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: var(--slider-thumb-size);
+  height: var(--slider-thumb-size);
+  background: var(--color-slider-thumb);
+  border-radius: 50%;
+  cursor: pointer;
+  border: none;
+}
+
+.range-input::-moz-range-thumb {
+  width: var(--slider-thumb-size);
+  height: var(--slider-thumb-size);
+  background: var(--color-slider-thumb);
+  border-radius: 50%;
+  cursor: pointer;
+  border: none;
+}
+
+.value-bubble {
+  position: absolute;
+  bottom: 0;
+  transform: translateX(-50%);
+  font-size: 12px;
+  color: var(--text-primary-color);
+}
+
+.min-label, .zero-label {
+  position: absolute;
+  bottom: 0;
+  left: 4px;
+  font-size: 12px;
+  color: var(--text-primary-color);
+}
+
+.max-label {
+  position: absolute;
+  bottom: 0;
+  right: 4px;
+  font-size: 12px;
+  color: var(--text-primary-color);
+}

--- a/src/frontend/src/ui/Range.scss
+++ b/src/frontend/src/ui/Range.scss
@@ -1,71 +1,79 @@
 :root {
   --slider-thumb-size: 16px;
+  --range-track-filled: #cc6d24;
+  --range-track-unfilled: #525252;
+  --range-thumb-color: #a4571b; /* Slightly lighter than track-filled for contrast */
 }
 
-.control-label {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  font-size: 0.9rem;
-  color: var(--text-primary-color);
-}
+.range {
+  &__control-label {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    font-size: 0.9rem;
+    color: var(--text-primary-color);
+  }
 
-.range-wrapper {
-  position: relative;
-  padding-top: 10px;
-  padding-bottom: 25px;
-  width: 100%;
-}
+  &__wrapper {
+    position: relative;
+    padding-top: 10px;
+    padding-bottom: 25px;
+    width: 100%;
+  }
 
-.range-input {
-  width: 100%;
-  height: 4px;
-  -webkit-appearance: none;
-  background: var(--color-slider-track);
-  border-radius: 2px;
-  outline: none;
-}
+  &__input {
+    width: 100%;
+    height: 4px;
+    -webkit-appearance: none;
+    background: var(--range-track-filled);
+    border-radius: 2px;
+    outline: none;
 
-.range-input::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  width: var(--slider-thumb-size);
-  height: var(--slider-thumb-size);
-  background: var(--color-slider-thumb);
-  border-radius: 50%;
-  cursor: pointer;
-  border: none;
-}
+    &::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      width: var(--slider-thumb-size);
+      height: var(--slider-thumb-size);
+      background: var(--range-thumb-color);
+      border-radius: 50%;
+      cursor: pointer;
+      border: none;
+    }
 
-.range-input::-moz-range-thumb {
-  width: var(--slider-thumb-size);
-  height: var(--slider-thumb-size);
-  background: var(--color-slider-thumb);
-  border-radius: 50%;
-  cursor: pointer;
-  border: none;
-}
+    &::-moz-range-thumb {
+      width: var(--slider-thumb-size);
+      height: var(--slider-thumb-size);
+      background: var(--range-thumb-color);
+      border-radius: 50%;
+      cursor: pointer;
+      border: none;
+    }
+  }
 
-.value-bubble {
-  position: absolute;
-  bottom: 0;
-  transform: translateX(-50%);
-  font-size: 12px;
-  color: var(--text-primary-color);
-}
+  &__value-bubble {
+    position: absolute;
+    bottom: 0;
+    transform: translateX(-50%);
+    font-size: 12px;
+    color: var(--text-primary-color);
+  }
 
-.min-label, .zero-label {
-  position: absolute;
-  bottom: 0;
-  left: 4px;
-  font-size: 12px;
-  color: var(--text-primary-color);
-}
+  &__label {
+    position: absolute;
+    bottom: 0;
+    font-size: 12px;
+    color: var(--text-primary-color);
 
-.max-label {
-  position: absolute;
-  bottom: 0;
-  right: 4px;
-  font-size: 12px;
-  color: var(--text-primary-color);
+    &--min {
+      left: 4px;
+    }
+
+    &--zero {
+      left: 4px;
+    }
+
+    &--max {
+      right: 4px;
+    }
+  }
 }

--- a/src/frontend/src/ui/Range.tsx
+++ b/src/frontend/src/ui/Range.tsx
@@ -8,7 +8,6 @@ export type RangeProps = {
   min?: number;
   max?: number;
   step?: number;
-  label?: string;
   minLabel?: string;
   maxLabel?: string;
   showValueBubble?: boolean;
@@ -43,13 +42,13 @@ export const Range = ({
       
       // Calculate percentage for gradient
       const percentage = ((value - min) / (max - min)) * 100;
-      rangeElement.style.background = `linear-gradient(to right, var(--color-slider-track) 0%, var(--color-slider-track) ${percentage}%, var(--button-bg) ${percentage}%, var(--button-bg) 100%)`;
+      rangeElement.style.background = `linear-gradient(to right, var(--range-track-filled) 0%, var(--range-track-filled) ${percentage}%, var(--range-track-unfilled) ${percentage}%, var(--range-track-unfilled) 100%)`;
     }
   }, [value, min, max, showValueBubble]);
 
   return (
-    <label className="control-label">
-      <div className="range-wrapper">
+    <label className="range range__control-label">
+      <div className="range__wrapper">
         <input
           ref={rangeRef}
           type="range"
@@ -60,19 +59,19 @@ export const Range = ({
             onChange(+event.target.value);
           }}
           value={value}
-          className="range-input"
+          className="range__input"
         />
         {showValueBubble && (
-          <div className="value-bubble" ref={valueRef}>
+          <div className="range__value-bubble" ref={valueRef}>
             {value !== min ? value : null}
           </div>
         )}
         {min === 0 ? (
-          <div className="zero-label">{minLabel || min}</div>
+          <div className="range__label range__label--zero">{minLabel || min}</div>
         ) : (
-          <div className="min-label">{minLabel || min}</div>
+          <div className="range__label range__label--min">{minLabel || min}</div>
         )}
-        <div className="max-label">{maxLabel || max}</div>
+        <div className="range__label range__label--max">{maxLabel || max}</div>
       </div>
     </label>
   );

--- a/src/frontend/src/ui/Range.tsx
+++ b/src/frontend/src/ui/Range.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect } from "react";
+
+import "./Range.scss";
+
+export type RangeProps = {
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  label?: string;
+  minLabel?: string;
+  maxLabel?: string;
+  showValueBubble?: boolean;
+};
+
+export const Range = ({
+  value,
+  onChange,
+  min = 0,
+  max = 100,
+  step = 1,
+  minLabel,
+  maxLabel,
+  showValueBubble = true,
+}: RangeProps) => {
+  const rangeRef = React.useRef<HTMLInputElement>(null);
+  const valueRef = React.useRef<HTMLDivElement>(null);
+  
+  useEffect(() => {
+    if (rangeRef.current) {
+      const rangeElement = rangeRef.current;
+      
+      // Update value bubble position if it exists
+      if (showValueBubble && valueRef.current) {
+        const valueElement = valueRef.current;
+        const inputWidth = rangeElement.offsetWidth;
+        const thumbWidth = 16; // Match the --slider-thumb-size CSS variable
+        const position =
+          ((value - min) / (max - min)) * (inputWidth - thumbWidth) + thumbWidth / 2;
+        valueElement.style.left = `${position}px`;
+      }
+      
+      // Calculate percentage for gradient
+      const percentage = ((value - min) / (max - min)) * 100;
+      rangeElement.style.background = `linear-gradient(to right, var(--color-slider-track) 0%, var(--color-slider-track) ${percentage}%, var(--button-bg) ${percentage}%, var(--button-bg) 100%)`;
+    }
+  }, [value, min, max, showValueBubble]);
+
+  return (
+    <label className="control-label">
+      <div className="range-wrapper">
+        <input
+          ref={rangeRef}
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          onChange={(event) => {
+            onChange(+event.target.value);
+          }}
+          value={value}
+          className="range-input"
+        />
+        {showValueBubble && (
+          <div className="value-bubble" ref={valueRef}>
+            {value !== min ? value : null}
+          </div>
+        )}
+        {min === 0 ? (
+          <div className="zero-label">{minLabel || min}</div>
+        ) : (
+          <div className="min-label">{minLabel || min}</div>
+        )}
+        <div className="max-label">{maxLabel || max}</div>
+      </div>
+    </label>
+  );
+};

--- a/src/frontend/src/ui/SettingsDialog.scss
+++ b/src/frontend/src/ui/SettingsDialog.scss
@@ -6,8 +6,6 @@
     right: 0;
     bottom: 0;
     z-index: 1000;
-    background-color: rgba(0, 0, 0, 0.2);
-    backdrop-filter: blur(1px);
   }
 
   &__title-container {
@@ -36,5 +34,42 @@
     height: 100%;
     color: #888;
     font-style: italic;
+  }
+
+  &__section {
+    margin-bottom: 1.5rem;
+  }
+
+  &__section-title {
+    margin: 0 0 1rem 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-primary-color);
+  }
+
+  &__setting {
+    margin-bottom: 1rem;
+    padding: 0.5rem;
+    border-radius: 4px;
+    background-color: var(--dialog-bg-color);
+  }
+
+  &__label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-size: 0.9rem;
+    color: var(--text-primary-color);
+  }
+
+  &__range-container {
+    margin: 1rem 0;
+  }
+
+  &__range-labels {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.8rem;
+    color: var(--text-primary-color);
+    opacity: 0.7;
   }
 }

--- a/src/frontend/src/ui/SettingsDialog.scss
+++ b/src/frontend/src/ui/SettingsDialog.scss
@@ -1,4 +1,9 @@
 .settings-dialog {
+
+  .control-label {
+    font-size: 0px;
+  }
+  
   &__wrapper {
     position: absolute;
     top: 0;
@@ -6,6 +11,8 @@
     right: 0;
     bottom: 0;
     z-index: 1000;
+    background-color: rgba(0, 0, 0, 0.2);
+    backdrop-filter: blur(1px);
   }
 
   &__title-container {

--- a/src/frontend/src/ui/SettingsDialog.scss
+++ b/src/frontend/src/ui/SettingsDialog.scss
@@ -1,0 +1,40 @@
+.settings-dialog {
+  &__wrapper {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1000;
+    background-color: rgba(0, 0, 0, 0.2);
+    backdrop-filter: blur(1px);
+  }
+
+  &__title-container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__title {
+    margin: 0;
+    font-size: 1.2rem;
+    font-weight: 600;
+  }
+
+  &__content {
+    padding: 1rem;
+    min-height: 200px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: #888;
+    font-style: italic;
+  }
+}

--- a/src/frontend/src/ui/SettingsDialog.scss
+++ b/src/frontend/src/ui/SettingsDialog.scss
@@ -1,8 +1,4 @@
 .settings-dialog {
-
-  .control-label {
-    font-size: 0px;
-  }
   
   &__wrapper {
     position: absolute;
@@ -34,15 +30,6 @@
     flex-direction: column;
   }
 
-  &__empty {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    color: #888;
-    font-style: italic;
-  }
-
   &__section {
     margin-bottom: 1.5rem;
   }
@@ -72,11 +59,4 @@
     margin: 1rem 0;
   }
 
-  &__range-labels {
-    display: flex;
-    justify-content: space-between;
-    font-size: 0.8rem;
-    color: var(--text-primary-color);
-    opacity: 0.7;
-  }
 }

--- a/src/frontend/src/ui/SettingsDialog.tsx
+++ b/src/frontend/src/ui/SettingsDialog.tsx
@@ -35,12 +35,17 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
     }
   }, [onClose]);
 
-  const handleEmbedLockDebounceTimeChange = (value: number) => {
+  /**
+   * Updates a specific setting and syncs it with the excalidraw app state
+   * @param key The setting key to update
+   * @param value The new value for the setting
+   */
+  const updateSetting = <K extends keyof UserSettings>(key: K, value: UserSettings[K]) => {
     if (!excalidrawAPI) return;
 
     const newSettings = {
       ...settings,
-      embedLockDebounceTime: value
+      [key]: value
     };
     
     setSettings(newSettings);
@@ -72,14 +77,14 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
           <div className="settings-dialog__range-container">
           <Range
             value={Math.round(((settings.embedLockDebounceTime || 350) - 150) / 4850 * 100)}
-            onChange={(value) => handleEmbedLockDebounceTimeChange(
+            onChange={(value) => updateSetting(
+              'embedLockDebounceTime',
               // Map 0-100 range to 150-5000ms
               Math.round(150 + (value / 100) * 4850)
             )}
             min={0}
             max={100}
             step={1}
-            label="Embed Lock Time"
             minLabel="150ms"
             maxLabel="5000ms"
             showValueBubble={false}

--- a/src/frontend/src/ui/SettingsDialog.tsx
+++ b/src/frontend/src/ui/SettingsDialog.tsx
@@ -1,0 +1,51 @@
+import React, { useState, useCallback } from "react";
+import { Dialog } from "@atyrode/excalidraw";
+import "./SettingsDialog.scss";
+
+interface SettingsDialogProps {
+  onClose?: () => void;
+}
+
+const SettingsDialog: React.FC<SettingsDialogProps> = ({
+  onClose,
+}) => {
+  const [modalIsShown, setModalIsShown] = useState(true);
+
+  const handleClose = useCallback(() => {
+    setModalIsShown(false);
+    if (onClose) {
+      onClose();
+    }
+  }, [onClose]);
+
+  // Dialog content
+  const dialogContent = (
+    <div className="settings-dialog__content">
+      {/* Settings content will go here in the future */}
+      <div className="settings-dialog__empty">Settings dialog is empty for now</div>
+    </div>
+  );
+
+  return (
+    <>
+      {modalIsShown && (
+        <div className="settings-dialog__wrapper">
+          <Dialog
+            className="settings-dialog"
+            size="small"
+            onCloseRequest={handleClose}
+            title={
+              <div className="settings-dialog__title-container">
+                <h2 className="settings-dialog__title">Settings</h2>
+              </div>
+            }
+            closeOnClickOutside={true}
+            children={dialogContent}
+          />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default SettingsDialog;

--- a/src/frontend/src/ui/SettingsDialog.tsx
+++ b/src/frontend/src/ui/SettingsDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect } from "react";
-import { Dialog, Range } from "@atyrode/excalidraw";
+import { Dialog } from "@atyrode/excalidraw";
+import { Range } from "./Range";
 import { UserSettings, DEFAULT_SETTINGS } from "../types/settings";
 import "./SettingsDialog.scss";
 
@@ -69,23 +70,20 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
             Embed Lock Debounce Time: {settings.embedLockDebounceTime}ms
           </label>
           <div className="settings-dialog__range-container">
-            <Range
-              updateData={(value) => handleEmbedLockDebounceTimeChange(
-                // Map 0-100 range to 150-5000ms
-                Math.round(150 + (value / 100) * 4850)
-              )}
-              appState={{
-                currentItemOpacity: 
-                  // Map 150-5000ms to 0-100 range
-                  Math.round(((settings.embedLockDebounceTime || 350) - 150) / 4850 * 100)
-              }}
-              elements={[]}
-              testId="embed-lock-debounce-time"
-            />
-          </div>
-          <div className="settings-dialog__range-labels">
-            <span>150ms</span>
-            <span>5000ms</span>
+          <Range
+            value={Math.round(((settings.embedLockDebounceTime || 350) - 150) / 4850 * 100)}
+            onChange={(value) => handleEmbedLockDebounceTimeChange(
+              // Map 0-100 range to 150-5000ms
+              Math.round(150 + (value / 100) * 4850)
+            )}
+            min={0}
+            max={100}
+            step={1}
+            label="Embed Lock Time"
+            minLabel="150ms"
+            maxLabel="5000ms"
+            showValueBubble={false}
+          />
           </div>
         </div>
       </div>

--- a/src/frontend/src/ui/SettingsDialog.tsx
+++ b/src/frontend/src/ui/SettingsDialog.tsx
@@ -1,15 +1,31 @@
-import React, { useState, useCallback } from "react";
-import { Dialog } from "@atyrode/excalidraw";
+import React, { useState, useCallback, useEffect } from "react";
+import { Dialog, Range } from "@atyrode/excalidraw";
+import { UserSettings, DEFAULT_SETTINGS } from "../types/settings";
 import "./SettingsDialog.scss";
 
 interface SettingsDialogProps {
+  excalidrawAPI?: any;
   onClose?: () => void;
 }
 
 const SettingsDialog: React.FC<SettingsDialogProps> = ({
+  excalidrawAPI,
   onClose,
 }) => {
   const [modalIsShown, setModalIsShown] = useState(true);
+  const [settings, setSettings] = useState<UserSettings>(DEFAULT_SETTINGS);
+
+  // Get current settings from excalidrawAPI when component mounts
+  useEffect(() => {
+    if (excalidrawAPI) {
+      const appState = excalidrawAPI.getAppState();
+      const userSettings = appState?.pad?.userSettings || {};
+      setSettings({
+        ...DEFAULT_SETTINGS,
+        ...userSettings
+      });
+    }
+  }, [excalidrawAPI]);
 
   const handleClose = useCallback(() => {
     setModalIsShown(false);
@@ -18,11 +34,61 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
     }
   }, [onClose]);
 
+  const handleEmbedLockDebounceTimeChange = (value: number) => {
+    if (!excalidrawAPI) return;
+
+    const newSettings = {
+      ...settings,
+      embedLockDebounceTime: value
+    };
+    
+    setSettings(newSettings);
+    
+    // Update the appState
+    const appState = excalidrawAPI.getAppState();
+    const updatedAppState = {
+      ...appState,
+      pad: {
+        ...appState.pad,
+        userSettings: newSettings
+      }
+    };
+    
+    excalidrawAPI.updateScene({
+      appState: updatedAppState
+    });
+  };
+
   // Dialog content
   const dialogContent = (
     <div className="settings-dialog__content">
-      {/* Settings content will go here in the future */}
-      <div className="settings-dialog__empty">Settings dialog is empty for now</div>
+      <div className="settings-dialog__section">
+        <h3 className="settings-dialog__section-title">Embed Settings</h3>
+        <div className="settings-dialog__setting">
+          <label className="settings-dialog__label">
+            Embed Lock Debounce Time: {settings.embedLockDebounceTime}ms
+          </label>
+          <div className="settings-dialog__range-container">
+            <Range
+              updateData={(value) => handleEmbedLockDebounceTimeChange(
+                // Map 0-100 range to 150-5000ms
+                Math.round(150 + (value / 100) * 4850)
+              )}
+              appState={{
+                currentItemOpacity: 
+                  // Map 150-5000ms to 0-100 range
+                  Math.round(((settings.embedLockDebounceTime || 350) - 150) / 4850 * 100)
+              }}
+              elements={[]}
+              testId="embed-lock-debounce-time"
+            />
+          </div>
+          <div className="settings-dialog__range-labels">
+            <span>150ms</span>
+            <span>5000ms</span>
+          </div>
+        </div>
+      </div>
     </div>
   );
 

--- a/src/frontend/src/ui/SettingsDialog.tsx
+++ b/src/frontend/src/ui/SettingsDialog.tsx
@@ -72,7 +72,7 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
         <h3 className="settings-dialog__section-title">Embed Settings</h3>
         <div className="settings-dialog__setting">
           <label className="settings-dialog__label">
-            Embed Lock Debounce Time: {settings.embedLockDebounceTime}ms
+            Embed Lock Time: {settings.embedLockDebounceTime}ms
           </label>
           <div className="settings-dialog__range-container">
           <Range

--- a/src/frontend/src/ui/SettingsDialog.tsx
+++ b/src/frontend/src/ui/SettingsDialog.tsx
@@ -79,8 +79,8 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
             value={Math.round(((settings.embedLockDebounceTime || 350) - 150) / 4850 * 100)}
             onChange={(value) => updateSetting(
               'embedLockDebounceTime',
-              // Map 0-100 range to 150-5000ms
-              Math.round(150 + (value / 100) * 4850)
+              // Map 0-100 range to 150-5000ms, rounded to nearest multiple of 50
+              Math.round((150 + (value / 100) * 4850) / 50) * 50
             )}
             min={0}
             max={100}

--- a/src/frontend/src/utils/canvasUtils.ts
+++ b/src/frontend/src/utils/canvasUtils.ts
@@ -1,9 +1,6 @@
+import { DEFAULT_SETTINGS } from '../types/settings';
+
 /**
- * Normalizes canvas data by removing width and height properties from appState
- * and resetting collaborators to an empty Map.
- * 
- * This is necessary when loading canvas data to ensure it fits properly in the current viewport
- * and doesn't carry over collaborator information that might be stale.
  * 
  * @param data The canvas data to normalize
  * @returns Normalized canvas data
@@ -21,6 +18,11 @@ export function normalizeCanvasData(data: any) {
     delete appState.height;
   }
 
+  // Preserve existing pad settings if they exist, otherwise create new ones
+  const existingPad = appState.pad || {};
+  const existingUserSettings = existingPad.userSettings || {};
+  
+  // Merge existing user settings with default settings
   appState.pad = { 
     moduleBorderOffset: {
       left: 10,
@@ -28,6 +30,11 @@ export function normalizeCanvasData(data: any) {
       top: 40,
       bottom: 10,
     },
+    // Merge existing user settings with default settings
+    userSettings: {
+      ...DEFAULT_SETTINGS,
+      ...existingUserSettings
+    }
   };
   
   // Reset collaborators (https://github.com/excalidraw/excalidraw/issues/8637)

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@atyrode/excalidraw@^0.18.0-3":
-  version "0.18.0-3"
-  resolved "https://registry.yarnpkg.com/@atyrode/excalidraw/-/excalidraw-0.18.0-3.tgz#445176d5b9828f033205a46f227fd76e722019ec"
-  integrity sha512-iWLyYMZNV9VQCcWAtrLmg52NkfCw1CDrigXXRrxa3H2KW6nyrlbFm3KZAF5Y0mOJDYzAtxclPvHoTvcRruMjGg==
+"@atyrode/excalidraw@^0.18.0-4":
+  version "0.18.0-4"
+  resolved "https://registry.yarnpkg.com/@atyrode/excalidraw/-/excalidraw-0.18.0-4.tgz#3350bd09533cb424105fa615ec0e2e4e243f798e"
+  integrity sha512-MDYAXT34cNmhoc49eC7iuoweGHsirKKH0VnwDT9CJPWTjUfOrXp/NsL1PHyFIyhBu14NI1osSpGTD0qi1FPegQ==
   dependencies:
     "@braintree/sanitize-url" "6.0.2"
     "@excalidraw/laser-pointer" "1.3.1"


### PR DESCRIPTION
This adds a new Settings menu in the main menu of [pad.ws](https://pad.ws):
![Screenshot 2025-04-28 at 03 43 53](https://github.com/user-attachments/assets/597394df-b265-4f9a-9885-8696129f783b)

Currently, it allows to change the "lock time" of embeds when scrolling the view to move around:
![Screenshot 2025-04-28 at 03 45 28](https://github.com/user-attachments/assets/0011796a-590a-4e18-998d-c2f4fd20cdcd)
