### PR TITLE
refactor: remove most of the telemetry

### DIFF
--- a/src/backend/routers/canvas.py
+++ b/src/backend/routers/canvas.py
@@ -40,29 +40,6 @@ async def save_canvas(data: Dict[str, Any], auth: SessionData = Depends(require_
     success = await store_canvas_data(user_id, data)
     if not success:
         raise HTTPException(status_code=500, detail="Failed to save canvas data")
-    # PostHog analytics: capture canvas_saved event
-    try:
-        app_state = data.get("appState", {})
-        width = app_state.get("width")
-        height = app_state.get("height")
-        zoom = app_state.get("zoom", {}).get("value")
-        full_url = None
-        if request:
-            full_url = str(request.base_url).rstrip("/") + str(request.url.path)
-            full_url = full_url.replace("http://", "https://")
-        posthog.capture(
-            distinct_id=user_id,
-            event="canvas_saved",
-            properties={
-                "pad_width": width,
-                "pad_height": height,
-                "pad_zoom": zoom,
-                "$current_url": full_url,
-            }
-        )
-    except Exception as e:
-        print(f"Error capturing canvas_saved event: {str(e)}")
-        pass
     return {"status": "success"}
 
 @canvas_router.get("")

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -2,7 +2,6 @@ import React, { useState, useCallback, useEffect, useRef } from "react";
 import { useCanvas, useDefaultCanvas, useUserProfile } from "./api/hooks";
 import { ExcalidrawWrapper } from "./ExcalidrawWrapper";
 import { debounce } from "./utils/debounce";
-import { capture } from "./utils/posthog";
 import posthog from "./utils/posthog";
 import { normalizeCanvasData } from "./utils/canvasUtils";
 import { useSaveCanvas } from "./api/hooks";
@@ -55,16 +54,6 @@ export default function App({
       console.error("[pad.ws] Failed to save canvas to database:", error);
     }
   });
-
-  useEffect(() => {
-    if (excalidrawAPI) {
-      (window as any).excalidrawAPI = excalidrawAPI;
-      capture('app_loaded');
-    }
-    return () => {
-      (window as any).excalidrawAPI = null;
-    };
-  }, [excalidrawAPI]);
 
   const lastSentCanvasDataRef = useRef<string>("");
 

--- a/src/frontend/src/ExcalidrawWrapper.tsx
+++ b/src/frontend/src/ExcalidrawWrapper.tsx
@@ -9,6 +9,7 @@ import { lockEmbeddables, renderCustomEmbeddable } from './CustomEmbeddableRende
 import AuthDialog from './ui/AuthDialog';
 import BackupsModal from './ui/BackupsDialog';
 import SettingsDialog from './ui/SettingsDialog';
+import { capture } from './utils/posthog';
 
 const defaultInitialData = {
   elements: [],
@@ -56,6 +57,7 @@ export const ExcalidrawWrapper: React.FC<ExcalidrawWrapperProps> = ({
   useEffect(() => {
     if (isAuthenticated === true) {
       setIsExiting(true);
+      capture('signed_in');
     }
   }, [isAuthenticated]);
   

--- a/src/frontend/src/pad/buttons/ActionButton.tsx
+++ b/src/frontend/src/pad/buttons/ActionButton.tsx
@@ -311,8 +311,7 @@ const ActionButton: React.FC<ActionButtonProps> = ({
 
   
   const executeAction = () => {
-    // Track button click event with PostHog
-    capture('custom_button_clicked', {
+    capture('action_button_clicked', {
       target: selectedTarget,
       action: selectedAction,
       codeVariant: selectedTarget === 'code' ? selectedCodeVariant : null
@@ -345,11 +344,6 @@ const ActionButton: React.FC<ActionButtonProps> = ({
       
       console.debug(`[pad.ws] Embedded ${selectedTarget} at URL: ${baseUrl}`);
       
-      // Track successful embed action
-      capture('embed_created', {
-        target: selectedTarget,
-        url: baseUrl
-      });
     } else if (selectedAction === 'open-tab') {
       const baseUrl = getUrl();
       if (!baseUrl) {
@@ -360,11 +354,6 @@ const ActionButton: React.FC<ActionButtonProps> = ({
       console.debug(`[pad.ws] Opening ${selectedTarget} in new tab from ${baseUrl}`);
       window.open(baseUrl, '_blank');
       
-      // Track tab open action
-      capture('tab_opened', {
-        target: selectedTarget,
-        url: baseUrl
-      });
     } else if (selectedAction === 'magnet') {
       if (!workspaceState) {
         console.error('Workspace state not available for magnet link');
@@ -386,13 +375,6 @@ const ActionButton: React.FC<ActionButtonProps> = ({
         magnetLink = `${prefix}://coder.coder-remote/open?owner=${owner}&workspace=${workspace}&url=${url}&token=&openRecent=true&agent=${agent}`;
         console.debug(`[pad.ws] Opening ${selectedCodeVariant} desktop app with magnet link: ${magnetLink}`);
         window.open(magnetLink, '_blank');
-        
-        // Track desktop app open action
-        capture('desktop_app_opened', {
-          target: selectedTarget,
-          codeVariant: selectedCodeVariant,
-          workspace: workspace
-        });
       }
     }
   };
@@ -425,14 +407,6 @@ const ActionButton: React.FC<ActionButtonProps> = ({
     e.stopPropagation(); 
     const newShowOptions = !showOptions;
     setShowOptions(newShowOptions);
-    
-    // Track settings toggle event
-    capture('custom_button_edit_settings', {
-      target: selectedTarget,
-      action: selectedAction,
-      codeVariant: selectedTarget === 'code' ? selectedCodeVariant : null,
-      showOptions: newShowOptions
-    });
     
     if (onSettingsToggle) {
       onSettingsToggle(newShowOptions);

--- a/src/frontend/src/utils/posthog.ts
+++ b/src/frontend/src/utils/posthog.ts
@@ -4,13 +4,6 @@ import posthog from 'posthog-js';
 if (import.meta.env.VITE_PUBLIC_POSTHOG_KEY) {
   posthog.init(import.meta.env.VITE_PUBLIC_POSTHOG_KEY, {
     api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
-    debug: false,
-    session_recording: {
-      recordCrossOriginIframes: true,
-      captureCanvas: {
-        recordCanvas: false,
-      }
-    },
   });
   console.debug('[pad.ws] PostHog initialized successfully');
 } else {


### PR DESCRIPTION
- Removed the canvas_saved event tracking from the save_canvas function in canvas.py to streamline the code.
- Updated the App component to eliminate the app_loaded event tracking.
- Integrated PostHog capture in ExcalidrawWrapper for user sign-in events.
- Refactored ActionButton to update event names for better clarity and removed redundant tracking calls.
- Simplified PostHog initialization by removing unnecessary session recording options.