### PR TITLE
fix: re-integrate excalidrawAPI into window object

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -55,6 +55,16 @@ export default function App({
     }
   });
 
+
+  useEffect(() => {
+    if (excalidrawAPI) {
+      (window as any).excalidrawAPI = excalidrawAPI;
+    }
+    return () => {
+      (window as any).excalidrawAPI = null;
+    };
+  }, [excalidrawAPI]);
+
   const lastSentCanvasDataRef = useRef<string>("");
 
   const debouncedLogChange = useCallback(


### PR DESCRIPTION
I was too zealous in #41 and removed a workaround making Action Button possible (for now). This PR restores the functionnality.