### PR TITLE
feat: add persistent terminal module

### DIFF
--- a/src/backend/default_canvas.json
+++ b/src/backend/default_canvas.json
@@ -2176,7 +2176,8 @@
             "boundElements": [],
             "backgroundColor": "#e9ecef",
             "customData": {
-                "showHyperlinkIcon": false
+                "showHyperlinkIcon": false,
+                "showClickableHint": false
             }
         }
     ]

--- a/src/frontend/src/CustomEmbeddableRenderer.tsx
+++ b/src/frontend/src/CustomEmbeddableRenderer.tsx
@@ -9,6 +9,7 @@ import {
   ControlButton,
   HtmlEditor,
   Editor,
+  Terminal,
 } from './pad';
 import { ActionButton } from './pad/buttons';
 import "./CustomEmbeddableRenderer.scss";
@@ -20,6 +21,7 @@ export const renderCustomEmbeddable = (
 ) => {
 
   if (element.link && element.link.startsWith('!')) {
+
     let path = element.link.split('!')[1];
     let content;
     let title;
@@ -28,9 +30,14 @@ export const renderCustomEmbeddable = (
       case 'html':
         content = <HtmlEditor element={element} appState={appState} excalidrawAPI={excalidrawAPI} />;
         title = "HTML Editor";
+        break;
       case 'editor':
         content = <Editor element={element} appState={appState} excalidrawAPI={excalidrawAPI} />;
         title = "Code Editor";
+        break;
+      case 'terminal':
+        content = <Terminal element={element} appState={appState} excalidrawAPI={excalidrawAPI} />;
+        title = "Terminal";
         break;
       case 'state':
         content = <StateIndicator />;

--- a/src/frontend/src/pad/containers/Terminal.scss
+++ b/src/frontend/src/pad/containers/Terminal.scss
@@ -1,0 +1,18 @@
+.terminal-container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.terminal-iframe {
+  flex: 1;
+  background-color: #1e1e1e;
+  height: 100%;
+  width: 100%;
+  border: 0px !important;
+  overflow: hidden;
+  border-bottom-left-radius: var(--embeddable-radius);
+  border-bottom-right-radius: var(--embeddable-radius);
+}

--- a/src/frontend/src/pad/containers/Terminal.tsx
+++ b/src/frontend/src/pad/containers/Terminal.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useWorkspaceState } from '../../api/hooks';
+import type { NonDeleted, ExcalidrawEmbeddableElement } from '@atyrode/excalidraw/element/types';
+import type { AppState } from '@atyrode/excalidraw/types';
+import './Terminal.scss';
+
+interface TerminalProps {
+  element: NonDeleted<ExcalidrawEmbeddableElement>;
+  appState: AppState;
+  excalidrawAPI?: any;
+}
+
+export const Terminal: React.FC<TerminalProps> = ({
+  element,
+  appState,
+  excalidrawAPI
+}) => {
+  const { data: workspaceState } = useWorkspaceState();
+  
+  const getTerminalUrl = () => {
+    if (!workspaceState) {
+      return 'https://terminal.example.dev';
+    }
+    
+    return `${workspaceState.base_url}/@${workspaceState.username}/${workspaceState.workspace_id}.${workspaceState.agent}/terminal`;
+  };
+
+  const terminalUrl = getTerminalUrl();
+
+  return (
+    <div className="terminal-container">
+      <iframe 
+        className="terminal-iframe" 
+        src={terminalUrl} 
+        title="Terminal"
+      />
+    </div>
+  );
+};
+
+export default Terminal;

--- a/src/frontend/src/pad/containers/Terminal.tsx
+++ b/src/frontend/src/pad/containers/Terminal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useWorkspaceState } from '../../api/hooks';
 import type { NonDeleted, ExcalidrawEmbeddableElement } from '@atyrode/excalidraw/element/types';
 import type { AppState } from '@atyrode/excalidraw/types';
@@ -10,19 +10,164 @@ interface TerminalProps {
   excalidrawAPI?: any;
 }
 
+// Interface for terminal connection info stored in customData
+interface TerminalConnectionInfo {
+  terminalId: string;
+  baseUrl?: string;
+  username?: string;
+  workspaceId?: string;
+  agent?: string;
+}
+
 export const Terminal: React.FC<TerminalProps> = ({
   element,
   appState,
   excalidrawAPI
 }) => {
   const { data: workspaceState } = useWorkspaceState();
+  const [terminalId, setTerminalId] = useState<string | null>(null);
+  const elementIdRef = useRef(element?.id);
+  const isInitializedRef = useRef(false);
+
+  // Generate a UUID for terminal ID
+  const generateUUID = () => {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      const r = Math.random() * 16 | 0;
+      const v = c === 'x' ? r : (r & 0x3 | 0x8);
+      return v.toString(16);
+    });
+  };
+
+  // Save terminal connection info to element's customData
+  const saveConnectionInfoToCustomData = useCallback(() => {
+    if (!element || !excalidrawAPI || !workspaceState || !terminalId) return;
+    
+    try {
+      // Get all elements from the scene
+      const elements = excalidrawAPI.getSceneElements();
+      
+      // Find and update the element
+      const updatedElements = elements.map(el => {
+        if (el.id === element.id) {
+          // Create a new customData object with the terminal connection info
+          const connectionInfo: TerminalConnectionInfo = {
+            terminalId,
+            baseUrl: workspaceState.base_url,
+            username: workspaceState.username,
+            workspaceId: workspaceState.workspace_id,
+            agent: workspaceState.agent
+          };
+          
+          const customData = {
+            ...(el.customData || {}),
+            terminalConnectionInfo: connectionInfo
+          };
+          
+          return { ...el, customData };
+        }
+        return el;
+      });
+      
+      // Update the scene with the modified elements
+      excalidrawAPI.updateScene({
+        elements: updatedElements
+      });
+    } catch (error) {
+      console.error('Error saving terminal connection info:', error);
+    }
+  }, [element, excalidrawAPI, workspaceState, terminalId]);
+
+  // Generate a terminal ID if one doesn't exist
+  useEffect(() => {
+    if (terminalId) return;
+    
+    // Generate a new terminal ID
+    const newTerminalId = generateUUID();
+    setTerminalId(newTerminalId);
+  }, [terminalId]);
   
-  const getTerminalUrl = () => {
-    if (!workspaceState) {
-      return 'https://terminal.example.dev';
+  // Initialize terminal connection info
+  useEffect(() => {
+    if (!element || !workspaceState || !terminalId || isInitializedRef.current) return;
+    
+    // Check if element ID has changed (indicating a new element)
+    if (element.id !== elementIdRef.current) {
+      elementIdRef.current = element.id;
     }
     
-    return `${workspaceState.base_url}/@${workspaceState.username}/${workspaceState.workspace_id}.${workspaceState.agent}/terminal`;
+    // Check if element already has terminal connection info
+    if (element.customData?.terminalConnectionInfo) {
+      const connectionInfo = element.customData.terminalConnectionInfo as TerminalConnectionInfo;
+      setTerminalId(connectionInfo.terminalId);
+    } else if (excalidrawAPI) {
+      // Save the terminal ID to customData
+      saveConnectionInfoToCustomData();
+    }
+    
+    isInitializedRef.current = true;
+  }, [element, workspaceState, terminalId, saveConnectionInfoToCustomData, excalidrawAPI]);
+
+  // Update terminal connection info when element changes
+  useEffect(() => {
+    if (!element || !workspaceState) return;
+    
+    // Check if element ID has changed (indicating a new element)
+    if (element.id !== elementIdRef.current) {
+      elementIdRef.current = element.id;
+      isInitializedRef.current = false;
+      
+      // Check if element already has terminal connection info
+      if (element.customData?.terminalConnectionInfo) {
+        const connectionInfo = element.customData.terminalConnectionInfo as TerminalConnectionInfo;
+        setTerminalId(connectionInfo.terminalId);
+      } else if (terminalId && excalidrawAPI) {
+        // Save the existing terminal ID to customData
+        saveConnectionInfoToCustomData();
+      } else if (!terminalId) {
+        // Generate a new terminal ID if one doesn't exist
+        const newTerminalId = generateUUID();
+        setTerminalId(newTerminalId);
+        
+        // Save the new terminal ID to customData if excalidrawAPI is available
+        if (excalidrawAPI) {
+          setTimeout(() => {
+            saveConnectionInfoToCustomData();
+          }, 100);
+        }
+      }
+      
+      isInitializedRef.current = true;
+    } else if (!isInitializedRef.current && terminalId && excalidrawAPI && !element.customData?.terminalConnectionInfo) {
+      // Handle the case where the element ID hasn't changed but we need to save the terminal ID
+      saveConnectionInfoToCustomData();
+      isInitializedRef.current = true;
+    }
+  }, [element, workspaceState, excalidrawAPI, terminalId, saveConnectionInfoToCustomData]);
+  
+  // Effect to handle excalidrawAPI becoming available after component mount
+  useEffect(() => {
+    if (!excalidrawAPI || !element || !workspaceState || !terminalId) return;
+    
+    // Check if element already has terminal connection info
+    if (element.customData?.terminalConnectionInfo) return;
+    
+    // Save the terminal ID to customData
+    saveConnectionInfoToCustomData();
+  }, [excalidrawAPI, element, workspaceState, terminalId, saveConnectionInfoToCustomData]);
+
+  const getTerminalUrl = () => {
+    if (!workspaceState) {
+      return '';
+    }
+    
+    const baseUrl = `${workspaceState.base_url}/@${workspaceState.username}/${workspaceState.workspace_id}.${workspaceState.agent}/terminal`;
+    
+    // Add reconnect parameter if terminal ID exists
+    if (terminalId) {
+      return `${baseUrl}?reconnect=${terminalId}`;
+    }
+    
+    return baseUrl;
   };
 
   const terminalUrl = getTerminalUrl();

--- a/src/frontend/src/pad/index.ts
+++ b/src/frontend/src/pad/index.ts
@@ -2,6 +2,7 @@
 export * from './controls/ControlButton';
 export * from './controls/StateIndicator';
 export * from './containers/Dashboard';
+export * from './containers/Terminal';
 export * from './buttons';
 export * from './editors';
 
@@ -9,3 +10,4 @@ export * from './editors';
 export { default as ControlButton } from './controls/ControlButton';
 export { default as StateIndicator } from './controls/StateIndicator';
 export { default as Dashboard } from './containers/Dashboard';
+export { default as Terminal } from './containers/Terminal';

--- a/src/frontend/src/ui/MainMenu.tsx
+++ b/src/frontend/src/ui/MainMenu.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import type { ExcalidrawImperativeAPI } from '@atyrode/excalidraw/types';
 import type { MainMenu as MainMenuType } from '@atyrode/excalidraw';
 
-import { LogOut, SquarePlus, LayoutDashboard, SquareCode, Eye, Coffee, Grid2x2, User, Text, ArchiveRestore, Settings } from 'lucide-react';
+import { LogOut, SquarePlus, LayoutDashboard, SquareCode, Eye, Coffee, Grid2x2, User, Text, ArchiveRestore, Settings, Terminal } from 'lucide-react';
 import { capture } from '../utils/posthog';
 import { ExcalidrawElementFactory, PlacementMode } from '../lib/ExcalidrawElementFactory';
 import { useUserProfile } from "../api/hooks";
@@ -100,6 +100,22 @@ export const MainMenuConfig: React.FC<MainMenuConfigProps> = ({
       scrollToView: true
     });
   };
+  
+  const handleTerminalClick = () => {
+    if (!excalidrawAPI) return;
+    
+    const terminalElement = ExcalidrawElementFactory.createEmbeddableElement({
+      link: "!terminal",
+      width: 800,
+      height: 500
+    });
+    
+    ExcalidrawElementFactory.placeInScene(terminalElement, excalidrawAPI, {
+      mode: PlacementMode.NEAR_VIEWPORT_CENTER,
+      bufferPercentage: 10,
+      scrollToView: true
+    });
+  };
 
   const handleCanvasBackupsClick = () => {
     setShowBackupsModal(true);
@@ -175,6 +191,12 @@ export const MainMenuConfig: React.FC<MainMenuConfigProps> = ({
           onClick={handleEditorClick}
         >
           Code Editor
+        </MainMenu.Item>
+        <MainMenu.Item
+          icon={<Terminal />}
+          onClick={handleTerminalClick}
+        >
+          Terminal
         </MainMenu.Item>
         <MainMenu.Item
           icon={<LayoutDashboard />}


### PR DESCRIPTION
This refactor the existing Terminal feature into its own component and exposes it as a module on [pad.ws](https://pad.ws) as !terminal:

![Screenshot 2025-04-28 at 06 03 15](https://github.com/user-attachments/assets/0510f6fc-b3fd-48f9-9c02-0dc2da69cc8e)

This also makes them persistent.