### PR TITLE
WIP: Rewrite auth for generic OIDC logins

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -24,9 +24,12 @@ KEYCLOAK_ADMIN=admin
 KEYCLOAK_ADMIN_PASSWORD=admin123
 
 # Fill this after you have created a realm and client in keycloak
-OIDC_REALM=your_realm
 OIDC_CLIENT_ID=your_client_id
 OIDC_CLIENT_SECRET=your_client_secret
+# DISCOVERY URL for your OIDC provider
+# Example for Keycloak: http://<KEYCLOAK-ENDPOINT>/realms/<REALM-ID>/.well-known/openid-configuration
+# Example for Authentik: http://<AUTHENTIK-ENDPOINT>/application/o/<PROVIDER-SLUG>/.well-known/openid-configuration
+OIDC_DISCOVERY_URL=your_discovery_url
 
 # Docker group id for coder, get it with: getent group docker | cut -d: -f3 
 DOCKER_GROUP_ID=your_docker_group_id

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "name": "Python Debugger: FastAPI",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "uvicorn",
+            "cwd": "${workspaceFolder}/src/backend",
+            "args": [
+                "main:app",
+                "--reload",
+                "--host", "0.0.0.0",
+                "--port", "8000"
+            ],
+            "jinja": true,
+            "envFile": "${workspaceFolder}/.env"
+        }
+    ]
+}

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -42,7 +42,7 @@ CODER_WORKSPACE_NAME = os.getenv("CODER_WORKSPACE_NAME", "ubuntu")
 # Cache for JWKS client
 _jwks_client = None
 
-# TODO
+# TODO deprecate this in favor of the newer implementation in dependencies.py
 def get_jwks_client():
     """Get or create a PyJWKClient for token verification"""
     global _jwks_client

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -1,12 +1,7 @@
 import os
 import json
-import time
-import httpx
-import jwt
 from jwt.jwks_client import PyJWKClient
-from typing import Optional, Dict, Any, Tuple
 from dotenv import load_dotenv
-from cache import RedisClient
 
 # Load environment variables once
 load_dotenv()
@@ -28,10 +23,9 @@ POSTHOG_API_KEY = os.getenv("VITE_PUBLIC_POSTHOG_KEY")
 POSTHOG_HOST = os.getenv("VITE_PUBLIC_POSTHOG_HOST")
 
 # ===== OIDC Configuration =====
+OIDC_DISCOVERY_URL = os.getenv("OIDC_DISCOVERY_URL")
 OIDC_CLIENT_ID = os.getenv('OIDC_CLIENT_ID')
 OIDC_CLIENT_SECRET = os.getenv('OIDC_CLIENT_SECRET')
-OIDC_SERVER_URL = os.getenv('OIDC_SERVER_URL')
-OIDC_REALM = os.getenv('OIDC_REALM')
 OIDC_REDIRECT_URI = os.getenv('REDIRECT_URI')
 
 default_pad = {}
@@ -48,6 +42,7 @@ CODER_WORKSPACE_NAME = os.getenv("CODER_WORKSPACE_NAME", "ubuntu")
 # Cache for JWKS client
 _jwks_client = None
 
+# TODO
 def get_jwks_client():
     """Get or create a PyJWKClient for token verification"""
     global _jwks_client

--- a/src/backend/dependencies.py
+++ b/src/backend/dependencies.py
@@ -25,6 +25,7 @@ async def get_session_domain() -> Session:
     """Get a Session domain instance for the current request."""
     redis_client = await RedisClient.get_instance()
     
+    # TODO Optimize this to avoid fetching OIDC config on every request
     async with httpx.AsyncClient() as client:
         oidc_response = await client.get(oidc_config['discovery_url'])
         if oidc_response.status_code != 200:

--- a/src/backend/domain/session.py
+++ b/src/backend/domain/session.py
@@ -88,12 +88,12 @@ class Session:
         Returns:
             The authentication URL
         """
-        auth_url = f"{self.oidc_config['server_url']}/realms/{self.oidc_config['realm']}/protocol/openid-connect/auth"
+        auth_url = self.oidc_config['authorization_endpoint']
         params = {
             'client_id': self.oidc_config['client_id'],
             'response_type': 'code',
             'redirect_uri': self.oidc_config['redirect_uri'],
-            'scope': 'openid profile email'
+            'scope': 'openid profile email offline_access'
         }
         return f"{auth_url}?{'&'.join(f'{k}={v}' for k,v in params.items())}"
 
@@ -104,7 +104,7 @@ class Session:
         Returns:
             The token endpoint URL
         """
-        return f"{self.oidc_config['server_url']}/realms/{self.oidc_config['realm']}/protocol/openid-connect/token"
+        return self.oidc_config['token_endpoint']
 
     def is_token_expired(self, token_data: Dict[str, Any], buffer_seconds: int = 30) -> bool:
         """
@@ -195,8 +195,7 @@ class Session:
             The JWKs client
         """
         if self._jwks_client is None:
-            jwks_url = f"{self.oidc_config['server_url']}/realms/{self.oidc_config['realm']}/protocol/openid-connect/certs"
-            self._jwks_client = PyJWKClient(jwks_url)
+            self._jwks_client = PyJWKClient(self.oidc_config['jwks_uri'])
         return self._jwks_client
 
     async def track_event(self, session_id: str, event_type: str, metadata: Dict[str, Any] = None) -> bool:

--- a/src/backend/domain/user.py
+++ b/src/backend/domain/user.py
@@ -1,3 +1,4 @@
+from random import Random
 from uuid import UUID
 from typing import Dict, Any, Optional, List
 from datetime import datetime
@@ -167,8 +168,10 @@ class User:
     @classmethod
     async def ensure_exists(cls, session: AsyncSession, user_info: dict) -> 'User':
         """Ensure a user exists in the database, creating them if they don't"""
-        # TODO Certain OIDC don't provide 'sub' in user_info as UUID, handle that case 
-        user_id = UUID(user_info['sub'])
+        # Certain OIDC don't provide 'sub' in user_info as UUID.
+        # So we have to generate a UUID based on the user 'sub' to ensure consistency
+        rng = Random(user_info['sub'])
+        user_id = UUID(int=rng.getrandbits(123)) 
         user = await cls.get_by_id(session, user_id)
         
         if not user:

--- a/src/backend/domain/user.py
+++ b/src/backend/domain/user.py
@@ -167,6 +167,7 @@ class User:
     @classmethod
     async def ensure_exists(cls, session: AsyncSession, user_info: dict) -> 'User':
         """Ensure a user exists in the database, creating them if they don't"""
+        # TODO Certain OIDC don't provide 'sub' in user_info as UUID, handle that case 
         user_id = UUID(user_info['sub'])
         user = await cls.get_by_id(session, user_id)
         


### PR DESCRIPTION
Hello I've been working on implementing standard OIDC login flows to not be locked into keycloak. 
I am opening the PR for visibility as I am only working on it on my spare time.

Known defects that still have to be fixed:
- [ ] There are two implementations of get_jwks_client.
- [ ] The OIDC discovery url is getting called more than once due to where I've implemented it.
- [ ] Groups and roles are passed differently by different providers (under `groups` in authentik and under `realm_access.roles` in keycloak)
- [ ] Refresh tokens don't have their expiration time shared by all providers