### PR TITLE
refactor: simplify main menu

### DIFF
--- a/src/frontend/src/ui/MainMenu.tsx
+++ b/src/frontend/src/ui/MainMenu.tsx
@@ -137,35 +137,6 @@ export const MainMenuConfig: React.FC<MainMenuConfigProps> = ({
     setShowAccountModal(true);
   };
 
-  const handleGridToggle = () => {
-    if (!excalidrawAPI) return;
-    const appState = excalidrawAPI.getAppState();
-    appState.gridModeEnabled = !appState.gridModeEnabled;
-    appState.gridSize = 20;
-    appState.gridStep = 5;
-    excalidrawAPI.updateScene({
-      appState: appState
-    });
-  };
-
-  const handleZenModeToggle = () => {
-    if (!excalidrawAPI) return;
-    const appState = excalidrawAPI.getAppState();
-    appState.zenModeEnabled = !appState.zenModeEnabled;
-    excalidrawAPI.updateScene({
-      appState: appState
-    });
-  };
-
-  const handleViewModeToggle = () => {
-    if (!excalidrawAPI) return;
-    const appState = excalidrawAPI.getAppState();
-    appState.viewModeEnabled = !appState.viewModeEnabled;
-    excalidrawAPI.updateScene({
-      appState: appState
-    });
-  };
-
   const handleLogout = async () => {
     capture('logout_clicked');
     
@@ -301,30 +272,6 @@ export const MainMenuConfig: React.FC<MainMenuConfigProps> = ({
         >
           Action Button
         </MainMenu.Item>
-      </MainMenu.Group>
-
-      <MainMenu.Separator />
-      
-      <MainMenu.Group title="View">
-        <MainMenu.Item
-          icon={<Grid2x2 />}
-          onClick={handleGridToggle}
-        >
-         Toggle grid
-        </MainMenu.Item>
-        <MainMenu.Item
-          icon={<Eye />}
-          onClick={handleViewModeToggle}
-        >
-          View mode
-        </MainMenu.Item>
-        <MainMenu.Item
-          icon={<Coffee />}
-          onClick={handleZenModeToggle}
-        >
-          Zen mode
-        </MainMenu.Item>
-
       </MainMenu.Group>
       
       <MainMenu.Separator />

--- a/src/frontend/src/ui/SettingsDialog.scss
+++ b/src/frontend/src/ui/SettingsDialog.scss
@@ -59,4 +59,78 @@
     margin: 1rem 0;
   }
 
+  &__restore-button {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    background-color: var(--button-bg-color, #cc6d24);
+    border: 1px solid var(--button-border-color, #ddd);
+    border-radius: 4px;
+    color: var(--text-primary-color);
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: background-color 0.2s ease;
+
+    &:hover {
+      background-color: var(--button-hover-bg-color, #a4571b);
+    }
+  }
+
+  &__confirmation {
+    padding: 1rem;
+    border-radius: 4px;
+    background-color: var(--dialog-bg-color);
+    border: 1px solid var(--warning-color, #f0ad4e);
+  }
+
+  &__warning {
+    color: var(--warning-color, #f0ad4e);
+    font-weight: bold;
+    margin: 1rem 0;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 1rem;
+  }
+
+  &__button {
+    padding: 8px 16px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    border: none;
+    transition: background-color 0.2s ease;
+
+    &--restore {
+      background-color: var(--danger-color, #d9534f);
+      color: white;
+
+      &:hover {
+        background-color: var(--danger-hover-color, #c9302c);
+      }
+
+      &:disabled {
+        background-color: var(--disabled-color, #cccccc);
+        cursor: not-allowed;
+      }
+    }
+
+    &--cancel {
+      background-color: var(--button-bg-color, #cc6d24);
+      border: 1px solid var(--button-border-color, #ddd);
+      color: var(--text-primary-color);
+
+      &:hover {
+        background-color: var(--button-hover-bg-color, #a4571b);
+      }
+
+      &:disabled {
+        background-color: var(--disabled-color, #cccccc);
+        cursor: not-allowed;
+      }
+    }
+  }
 }

--- a/src/frontend/src/ui/SettingsDialog.scss
+++ b/src/frontend/src/ui/SettingsDialog.scss
@@ -42,7 +42,6 @@
   }
 
   &__setting {
-    margin-bottom: 1rem;
     padding: 0.5rem;
     border-radius: 4px;
     background-color: var(--dialog-bg-color);

--- a/src/frontend/src/ui/SettingsDialog.tsx
+++ b/src/frontend/src/ui/SettingsDialog.tsx
@@ -147,7 +147,7 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
                 onClick={handleRestoreTutorialCanvas}
                 disabled={isRestoring}
               >
-                {isRestoring ? "Restoring..." : "Yes, Restore"}
+                {isRestoring ? "Restoring..." : "I'm sure"}
               </button>
               <button 
                 className="settings-dialog__button settings-dialog__button--cancel" 


### PR DESCRIPTION
- Removes "toggle grid", "view mode" and "zen mode" from the Main menu, as they are available on right clicking the canvas.
- Add a "restore tutorial canvas" button in settings