### PR TITLE
docs: update README with audience creation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,14 @@ This simplified example lets you host pad on `localhost` but is not safe for rea
     *   Fill in the details
     *   **Important:** Tick `Email verified`
     *   Go to the `Credentials` tab for the new user and set a password
-
+*   **Create an Audience:**
+    *   Navigate to `Clients` -> `[Your Client ID]` -> `Client Scopes`
+    *   Click on the dedicated scope of your Client (`[clientid]-dedicated`)
+    *   Click on `Configure a new mapper`
+    *   Then click on `Audience`
+    *   Ensure `Included Client Audience` matches your `Client ID`
+    *   Ensure `Add to access token` is On
+    
 ### 5️⃣ Coder 🧑‍💻
 
 *   **Find Docker Group ID:** You'll need this to grant necessary permissions


### PR DESCRIPTION
- Added detailed instructions for creating an audience in the Keycloak client settings, including configuration of client scopes and mappers.
- Enhanced clarity of the README to assist users in setting up audience management effectively.