### PR TITLE
fix: add user creation failsafe mechanism

### DIFF
--- a/src/backend/routers/pad_router.py
+++ b/src/backend/routers/pad_router.py
@@ -27,7 +27,8 @@ async def save_pad(
             pad = await pad_service.create_pad(
                 owner_id=user.id,
                 display_name=DEFAULT_PAD_NAME,
-                data=data
+                data=data,
+                token_data=user.token_data
             )
         else:
             # Update existing pad
@@ -99,7 +100,8 @@ async def create_pad_from_template(
         pad = await pad_service.create_pad(
             owner_id=user.id,
             display_name=display_name,
-            data=template["data"]
+            data=template["data"],
+            token_data=user.token_data
         )
         
         # Create an initial backup for the new pad


### PR DESCRIPTION
- Updated create_pad method in PadService to include token_data for user creation failsafe, allowing automatic user creation if the owner does not exist.
- Modified error handling in pad retrieval to return an empty list instead of raising an error when the owner is not found, improving API robustness.
- Adjusted pad_router to pass token_data during pad creation, ensuring user synchronization with authentication data.