### PR TITLE
fix: user creation failsafe to rely on UserSession

### DIFF
--- a/src/backend/routers/pad_router.py
+++ b/src/backend/routers/pad_router.py
@@ -28,7 +28,7 @@ async def save_pad(
                 owner_id=user.id,
                 display_name=DEFAULT_PAD_NAME,
                 data=data,
-                token_data=user.token_data
+                user_session=user
             )
         else:
             # Update existing pad
@@ -101,7 +101,7 @@ async def create_pad_from_template(
             owner_id=user.id,
             display_name=display_name,
             data=template["data"],
-            token_data=user.token_data
+            user_session=user
         )
         
         # Create an initial backup for the new pad


### PR DESCRIPTION
- Modified create_pad method in PadService to accept user_session instead of token_data, enhancing user creation logic when the owner does not exist.
- Improved error handling during user creation to manage potential race conditions and provide clearer logging.
- Updated pad_router to pass user_session during pad creation, ensuring synchronization with user authentication data.