### PR TITLE
fix: add CODER_WORKSPACE_NAME to .env.template and update README

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -35,3 +35,4 @@ CODER_ADDITIONAL_CSP_POLICY=frame-ancestors *
 CODER_API_KEY=your_coder_api_key
 CODER_TEMPLATE_ID=your_template_id
 CODER_DEFAULT_ORGANIZATION=your_organization_id
+CODER_WORKSPACE_NAME=your_workspace_name

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ This simplified example lets you host pad on `localhost` but is not safe for rea
         ```dotenv
         CODER_DEFAULT_ORGANIZATION=your_organization_id # Example: 70f6af06-ef3a-4b4c-a663-c03c9ee423bb
         ```
+*   **If you use a custom name for your workspace:**
+    *   You need to provide the name as `CODER_WORKSPACE_NAME` in your `.env`. Otherwise, it will assume your workspace name is the default we chose: `ubuntu`.
 
 ### 6️⃣ Pad App 📝
 > The fastAPI app that both serves the build frontend and the backend API to interface with Coder


### PR DESCRIPTION
This addresses the core issue of #67, where using a custom workspace name but not providing the `.env` value that matches it would have the backend default to assuming the workspace is called `ubuntu` which could critically fail the app's startup.

- Introduced a new environment variable, CODER_WORKSPACE_NAME, in the .env.template to allow users to specify a custom workspace name.
- Updated the README to include instructions for setting the CODER_WORKSPACE_NAME, enhancing clarity for users configuring their environment.