### PR TITLE
fix: correctly load default canvas in settings

### DIFF
--- a/src/frontend/src/api/hooks.ts
+++ b/src/frontend/src/api/hooks.ts
@@ -119,7 +119,7 @@ export const api = {
   getDefaultCanvas: async (): Promise<CanvasData> => {
     try {
       const result = await fetchApi('/api/templates/default');
-      return result;
+      return result.data;
     } catch (error) {
       throw error;
     }

--- a/src/frontend/src/ui/SettingsDialog.tsx
+++ b/src/frontend/src/ui/SettingsDialog.tsx
@@ -50,7 +50,8 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
       
       // Use the API function from hooks.ts to fetch the default canvas
       const defaultCanvasData = await api.getDefaultCanvas();
-      console.log("Default canvas data:", defaultCanvasData);
+      
+      console.debug("Default canvas data:", defaultCanvasData);
       
       // Normalize the canvas data before updating the scene
       const normalizedData = normalizeCanvasData(defaultCanvasData);
@@ -58,7 +59,7 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
       // Update the canvas with the normalized default data
       excalidrawAPI.updateScene(normalizedData);
       
-      console.log("Canvas reset to default successfully");
+      console.debug("Canvas reset to default successfully");
       
       // Close the dialog after successful restore
       handleClose();


### PR DESCRIPTION
This restores the functionnality of the "Reset to tutorial canvas" button in the settings.