### PR TITLE
feat: add devMode configuration to app settings endpoint

### DIFF
--- a/src/backend/routers/app_router.py
+++ b/src/backend/routers/app_router.py
@@ -32,5 +32,6 @@ async def get_app_config():
     return {
         "coderUrl": os.getenv("CODER_URL", ""),
         "posthogKey": os.getenv("VITE_PUBLIC_POSTHOG_KEY", ""),
-        "posthogHost": os.getenv("VITE_PUBLIC_POSTHOG_HOST", "")
+        "posthogHost": os.getenv("VITE_PUBLIC_POSTHOG_HOST", ""),
+        "devMode": os.getenv("PAD_DEV_MODE", "false") == "true",
     }

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -52,7 +52,7 @@ export default function App() {
   };
 
   useEffect(() => {
-    if (config?.posthogKey && config?.posthogHost) {
+    if (!config?.devMode && config?.posthogKey && config?.posthogHost) {
       initializePostHog({
         posthogKey: config.posthogKey,
         posthogHost: config.posthogHost,

--- a/src/frontend/src/hooks/useAppConfig.ts
+++ b/src/frontend/src/hooks/useAppConfig.ts
@@ -4,6 +4,7 @@ interface AppConfig {
   coderUrl: string;
   posthogKey: string;
   posthogHost: string;
+  devMode: boolean;
 }
 
 const fetchAppConfig = async (): Promise<AppConfig> => {
@@ -31,6 +32,7 @@ export const useAppConfig = () => {
     gcTime: Infinity, // Renamed from cacheTime in v5
   });
 
+  console.log('data', data);
   return {
     config: data,
     isLoadingConfig: isLoading,


### PR DESCRIPTION
This enables the frontend to disable posthog initialization, which in turns was obscuring the browser console logs during development.

- Introduced a new `devMode` property in the app configuration, allowing for conditional initialization of PostHog analytics based on the development environment.
- Updated the App component to check for `devMode` before initializing PostHog, enhancing control over analytics in development settings.
- Modified the AppConfig interface to include the new `devMode` boolean property for type safety.