### PR TITLE
add REDIRECT_URL to .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,6 +7,7 @@ APP_PORT=8000
 # API Configuration
 API_WORKERS=1
 FRONTEND_URL=your_frontend_url
+REDIRECT_URI=http://localhost:8000/api/auth/callback
 
 # Database Configuration
 POSTGRES_USER=admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
     restart: unless-stopped
     network_mode: host
-    
+
   redis:
     image: redis:alpine
     container_name: redis
@@ -78,7 +78,7 @@ services:
       - OIDC_CLIENT_SECRET=${OIDC_CLIENT_SECRET}
       - OIDC_SERVER_URL=http://localhost:${KEYCLOAK_PORT}
       - OIDC_REALM=${OIDC_REALM}
-      - REDIRECT_URI=http://localhost:${APP_PORT}/auth/callback
+      - REDIRECT_URI=${REDIRECT_URI}
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_DB=${POSTGRES_DB}


### PR DESCRIPTION
As mentioned in https://github.com/pad-ws/pad.ws/issues/102
we changed the route from `/auth/callback` to `/api/auth/callback`

This PR reflect this changes in `.env.template` and `docker-compose.yml` 



